### PR TITLE
Limit fixed checkpoint selection to parity_comp

### DIFF
--- a/parity_comp/utils.py
+++ b/parity_comp/utils.py
@@ -11,20 +11,8 @@ from models import DEVICE
 
 
 def pick_ckpts(pairs, surge_th: float = 0.03):
-    """Select checkpoints before, during and after accuracy surge and the best."""
-    pairs.sort(key=lambda x: x[0])
-    steps, accs = zip(*pairs)
-    diffs = np.diff(accs)
-    k = int(np.argmax(diffs))
-    pre = steps[max(k - 1, 0)]
-    during = steps[k]
-    post = during
-    for j in range(k + 1, len(diffs)):
-        if diffs[j] < surge_th:
-            post = steps[j + 1]
-            break
-    best = steps[int(np.argmax(accs))]
-    return sorted({pre, during, post, best})
+    """Return fixed checkpoint steps."""
+    return [20000, 30000, 50000]
 
 
 def pick_ckpts_phaseA(pairs, th: float = 0.03):


### PR DESCRIPTION
## Summary
- revert pick_ckpts logic in parity and parity_A modules
- keep simplified checkpoint function only for `parity_comp/utils.py`

## Testing
- `python -m py_compile parity/train.py parity_A/train_A.py parity_A/plotting.py parity_A/monomial.py parity_A/monomial2.py parity/monomial.py parity_comp/utils.py parity_comp/train.py bert_comp/train.py`


------
https://chatgpt.com/codex/tasks/task_e_684277bd1eb083209bdac9f8f992c4ae