### PR TITLE
Simplify parity_comp checkpoints only

### DIFF
--- a/parity_A/monomial2.py
+++ b/parity_A/monomial2.py
@@ -133,8 +133,6 @@ def main(args):
         rest_corr.append(corr[k:].mean())
         steps.append(step)
         # accuracy(선택용)
-        acc = (torch.softmax(mdl(next(iter(loader))[0].to(DEVICE)),dim=-1).argmax(-1)==
-               next(iter(loader))[1].to(DEVICE)).float().mean().item()
         acc = evaluate(mdl)
         acc_log.append((step, acc))
 

--- a/parity_comp/train.py
+++ b/parity_comp/train.py
@@ -27,13 +27,10 @@ from models import DEVICE, build_mlp, evaluate
 from training import train
 from utils import (
     pick_ckpts,
-    pick_ckpts_phaseA,
-    rise_region,
     best_mid_worst,
     plot_curve,
     corr_curve,
     move_keep,
-    nearest_logged_step,
 )
 
 # Main ------------------------------------------------------------------------
@@ -67,7 +64,7 @@ def main(cfg):
                  eval_steps=cfg.eval, save_steps=cfg.save,
                  max_steps=cfg.phase_steps)
     pairsA=[(h["step"],h["acc"]) for h in logA]
-    selA = pick_ckpts_phaseA(pairsA)
+    selA = pick_ckpts(pairsA)
     move_keep(out, selA, "PA", parity_dir/"phaseA")
     acc_bigT = evaluate(bigT, ev_global)
     plot_curve(
@@ -107,12 +104,10 @@ def main(cfg):
                      eval_steps=cfg.eval, save_steps=cfg.save,
                      max_steps=cfg.phase_steps)
         pairsB=[(h["step"],h["acc"]) for h in logB]
-        bestB,midB,_=best_mid_worst(pairsB)
-        s_rs, e_rs, midRise = rise_region(pairsB, Δ=0.005)
-        if midRise:
-            midRise = nearest_logged_step(midRise, pairsB)
-        keepB = [bestB[0], midB[0], midRise] if midRise else [bestB[0], midB[0]]
-        if bestB[1] < 0.6: keepB=[]    # skip set
+        bestB,_,_ = best_mid_worst(pairsB)
+        keepB = pick_ckpts(pairsB)
+        if bestB[1] < 0.6:
+            keepB = []    # skip set
         move_keep(out, keepB, tagB, parity_dir/f"phaseB_set{set_idx}")
         plot_curve(
             pairsB,
@@ -149,11 +144,8 @@ def main(cfg):
                          eval_steps=cfg.eval, save_steps=cfg.save,
                          max_steps=cfg.phase_steps)
             pairsC=[(h["step"],h["acc"]) for h in logC]
-            bestC,midC,_=best_mid_worst(pairsC)
-            sC, eC, midRiseC = rise_region(pairsC, Δ=0.005)
-            if midRiseC:
-                midRiseC = nearest_logged_step(midRiseC, pairsC)
-            keepC = [bestC[0], midRiseC, midC[0]] if midRiseC else [bestC[0], midC[0]]
+            bestC,_,_ = best_mid_worst(pairsC)
+            keepC = pick_ckpts(pairsC)
             move_keep(out, keepC, tagC, parity_dir/f"phaseC_set{set_idx}_{sub_idx}")
             plot_curve(
                 pairsC,

--- a/parity_comp/utils.py
+++ b/parity_comp/utils.py
@@ -11,20 +11,8 @@ from models import DEVICE
 
 
 def pick_ckpts(pairs, surge_th: float = 0.03):
-    """Select checkpoints before, during and after accuracy surge and the best."""
-    pairs.sort(key=lambda x: x[0])
-    steps, accs = zip(*pairs)
-    diffs = np.diff(accs)
-    k = int(np.argmax(diffs))
-    pre = steps[max(k - 1, 0)]
-    during = steps[k]
-    post = during
-    for j in range(k + 1, len(diffs)):
-        if diffs[j] < surge_th:
-            post = steps[j + 1]
-            break
-    best = steps[int(np.argmax(accs))]
-    return sorted({pre, during, post, best})
+    """Return the fixed checkpoint steps [20000, 30000, 50000]."""
+    return [20000, 30000, 50000]
 
 
 def pick_ckpts_phaseA(pairs, th: float = 0.03):
@@ -95,7 +83,11 @@ def corr_curve(ckpt_pattern: str, model_fn, dim, k, lab, out_path, loader, out_j
     plt.tight_layout(); plt.savefig(out_path, dpi=250); plt.close()
     if out_json:
         Path(out_json).parent.mkdir(parents=True, exist_ok=True)
-        json.dump({"step": xs, "corr": ys}, open(out_json, "w"), indent=2)
+        json.dump(
+            {"step": [int(s) for s in xs], "corr": [float(c) for c in ys]},
+            open(out_json, "w"),
+            indent=2,
+        )
 
 
 def move_keep(src_root: Path, keep_steps: List[int], tag: str, dst_root: Path):


### PR DESCRIPTION
## Summary
- keep constant checkpoint list only in `parity_comp`
- restore original dynamic checkpoint selection for other parity scripts
- keep improved JSON serialization and monomial2 accuracy fix

## Testing
- `python -m py_compile parity/train.py parity_A/train_A.py parity_A/plotting.py parity_A/monomial.py parity_A/monomial2.py parity/monomial.py parity_comp/utils.py parity_comp/train.py bert_comp/train.py`

------
https://chatgpt.com/codex/tasks/task_e_684277bd1eb083209bdac9f8f992c4ae